### PR TITLE
NMreadExt was incorrectly calculating blocksize for OMEGAs, I proposed a fix

### DIFF
--- a/R/NMreadExt.R
+++ b/R/NMreadExt.R
@@ -208,16 +208,15 @@ NMreadExt <- function(file,return,as.fun,modelname,col.model,auto.ext,tableno="m
         pars[,est:=value]
 
         ### add OMEGA block information based on off diagonal values
-        tab.blocks <- rbind(pars[par.type%in%c("OMEGA","SIGMA"),.(par.type,i=i,j=j,value)],
-                            pars[par.type%in%c("OMEGA","SIGMA"),.(par.type,i=j,j=i,value)])[
-                                abs(value)>1e-9,.(iblock=min(i,j)
-                                                  # ,blocksize=max(abs(j-i))+1
-                                ),by=.(par.type,i)]
-        tab.blocks[,blocksize:=length(i),by=.(par.type,iblock)]
+        tab.i <- rbind(pars[par.type%in%c("OMEGA","SIGMA"),.(par.type,i=i,j=j,value)],
+                       pars[par.type%in%c("OMEGA","SIGMA"),.(par.type,i=j,j=i,value)])[
+                # include i==j so that if an OMEGA is fixed to zero it is still assigned an iblock
+                                i==j|abs(value)>1e-9,.(iblock=min(i,j)),by=.(par.type,i)]
+        tab.i[,blocksize:=.N,by=.(par.type,iblock)]
 
         ## pars0 <- copy(pars)
         ## tab.blocks
-        pars <- mergeCheck(pars,tab.blocks,by=cc(par.type,i),all.x=T,quiet=TRUE)
+        pars <- mergeCheck(pars,tab.i,by=cc(par.type,i),all.x=T,quiet=TRUE)
 
         ## pars[par.type%in%c("OMEGA","SIGMA"),.(i,j,iblock,blocksize,value)]
 

--- a/R/NMreadExt.R
+++ b/R/NMreadExt.R
@@ -207,10 +207,13 @@ NMreadExt <- function(file,return,as.fun,modelname,col.model,auto.ext,tableno="m
         ## est is just a copy of value for backward compatibility
         pars[,est:=value]
 
-### add OMEGA block information based on off diagonal values
+        ### add OMEGA block information based on off diagonal values
         tab.blocks <- rbind(pars[par.type%in%c("OMEGA","SIGMA"),.(par.type,i=i,j=j,value)],
                             pars[par.type%in%c("OMEGA","SIGMA"),.(par.type,i=j,j=i,value)])[
-            abs(value)>1e-9,.(iblock=min(i,j),blocksize=max(abs(j-i))+1),by=.(par.type,i)]
+                                abs(value)>1e-9,.(iblock=min(i,j)
+                                                  # ,blocksize=max(abs(j-i))+1
+                                ),by=.(par.type,i)]
+        tab.blocks[,blocksize:=length(i),by=.(par.type,iblock)]
 
         ## pars0 <- copy(pars)
         ## tab.blocks


### PR DESCRIPTION
When Blocksize was >2, NMreadExt was incorrectly calculating blocksize for OMEGAS/SIGMAS blocks
